### PR TITLE
Revamp fortune chat UI and update tarot guidance

### DIFF
--- a/fortune-new.html
+++ b/fortune-new.html
@@ -7,6 +7,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.3/dist/purify.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;700;900&family=Noto+Sans+SC:wght@300;400;500;700&family=ZCOOL+KuaiLe&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -57,19 +59,71 @@
         }
         
         .chat-container {
-            max-height: 500px;
+            max-height: 520px;
             overflow-y: auto;
             scroll-behavior: smooth;
+            background: radial-gradient(circle at top, rgba(79, 70, 229, 0.12), rgba(10, 14, 39, 0.85));
+            border: 1px solid rgba(139, 92, 246, 0.4);
+            box-shadow: inset 0 0 30px rgba(139, 92, 246, 0.1);
         }
-        
+
+        .chat-message {
+            position: relative;
+            padding: 1rem;
+            border-radius: 1rem;
+            backdrop-filter: blur(6px);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            border: 1px solid transparent;
+        }
+
+        .chat-message:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+        }
+
         .ai-message {
-            background: linear-gradient(135deg, rgba(147, 51, 234, 0.2), rgba(79, 70, 229, 0.2));
-            border-left: 4px solid #8b5cf6;
+            background: linear-gradient(135deg, rgba(147, 51, 234, 0.3), rgba(79, 70, 229, 0.25));
+            border: 1px solid rgba(139, 92, 246, 0.4);
+            box-shadow: 0 10px 30px rgba(139, 92, 246, 0.25);
         }
-        
+
         .user-message {
-            background: linear-gradient(135deg, rgba(245, 158, 11, 0.2), rgba(217, 119, 6, 0.2));
-            border-left: 4px solid #f59e0b;
+            background: linear-gradient(135deg, rgba(245, 158, 11, 0.25), rgba(217, 119, 6, 0.2));
+            border: 1px solid rgba(245, 158, 11, 0.4);
+            box-shadow: 0 10px 30px rgba(245, 158, 11, 0.2);
+        }
+
+        .message-metadata {
+            font-size: 0.75rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        .message-content {
+            line-height: 1.7;
+        }
+
+        .message-content h2,
+        .message-content h3,
+        .message-content h4 {
+            color: #fcd34d;
+            font-weight: 700;
+            margin-top: 0.75rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .message-content p + p {
+            margin-top: 0.75rem;
+        }
+
+        .message-content ul,
+        .message-content ol {
+            margin-left: 1.25rem;
+            margin-top: 0.5rem;
+        }
+
+        .message-content ul li::marker {
+            color: #fbbf24;
         }
         
         .zodiac-display {
@@ -262,20 +316,47 @@
                     </div>
                     
                     <!-- 对话区域 -->
-                    <div id="chatContainer" class="chat-container border border-yellow-600 rounded-lg p-4 mb-6">
-                        <div id="chatMessages" class="space-y-4">
-                            <!-- 对话消息将在这里显示 -->
-                        </div>
+        <div id="chatContainer" class="chat-container rounded-2xl p-6 mb-6 space-y-4">
+            <div id="chatMessages" class="space-y-4">
+                <!-- 对话消息将在这里显示 -->
+            </div>
+        </div>
+
+        <!-- 用户输入区域 -->
+        <div id="userInputArea" class="flex space-x-4">
+            <textarea id="userInput" class="flex-1 px-4 py-3 rounded-lg input-field resize-none" rows="3"
+                placeholder="请详细描述您的情况..."></textarea>
+            <button onclick="sendMessage()" class="glow-button px-6 py-3 rounded-lg text-black font-bold">
+                发送
+            </button>
+        </div>
+
+        <div id="chatSummaryActions" class="hidden mt-6">
+            <div class="mystical-card rounded-2xl p-6">
+                <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+                    <div class="flex-1">
+                        <h3 class="text-2xl font-bold text-yellow-400 mb-2">📝 对话总结选项</h3>
+                        <p class="text-gray-300 text-sm leading-relaxed">
+                            是否需要我将本次对话和最初的问题进行简要归纳？您可以快速获取要点，再决定是否生成完整运势报告。
+                        </p>
                     </div>
-                    
-                    <!-- 用户输入区域 -->
-                    <div id="userInputArea" class="flex space-x-4">
-                        <textarea id="userInput" class="flex-1 px-4 py-3 rounded-lg input-field resize-none" rows="3" 
-                            placeholder="请详细描述您的情况..."></textarea>
-                        <button onclick="sendMessage()" class="glow-button px-6 py-3 rounded-lg text-black font-bold">
-                            发送
+                    <div class="flex flex-col sm:flex-row gap-3">
+                        <button id="generateSummaryBtn" onclick="requestChatSummary()"
+                            class="glow-button px-6 py-3 rounded-full text-black font-bold">
+                            🪄 生成对话总结
+                        </button>
+                        <button onclick="generateFinalReport()"
+                            class="border-2 border-yellow-400 text-yellow-400 hover:bg-yellow-400 hover:text-black px-6 py-3 rounded-full font-bold transition-all duration-300">
+                            📊 生成综合报告
                         </button>
                     </div>
+                </div>
+                <div id="chatSummaryResult" class="hidden mt-6 p-4 rounded-xl bg-black bg-opacity-40 border border-yellow-500/40">
+                    <h4 class="text-yellow-300 font-bold mb-3">✨ 运势要点总结</h4>
+                    <div id="chatSummaryContent" class="message-content text-gray-200 text-sm leading-relaxed"></div>
+                </div>
+            </div>
+        </div>
                 </div>
 
                 <!-- 步骤4：最终综合分析 -->
@@ -311,6 +392,14 @@
         let currentQuestionIndex = 0;
         let analysisData = {};
         let followUpQuestions = [];
+        let typingIndicator = null;
+        let summarySectionVisible = false;
+        let summaryGenerated = false;
+
+        marked.setOptions({
+            breaks: true,
+            gfm: true
+        });
 
         const defaultFollowUps = [
             "请详细描述一下您最近的心情状态和情绪变化？",
@@ -344,7 +433,13 @@
                 focusAreas,
                 zodiacSign: window.mysticalAI.getZodiacSign(birthDate)
             };
-            
+
+            summarySectionVisible = false;
+            summaryGenerated = false;
+            document.getElementById('chatSummaryActions').classList.add('hidden');
+            document.getElementById('chatSummaryResult').classList.add('hidden');
+            document.getElementById('chatSummaryContent').innerHTML = '';
+
             // 隐藏第一步，显示第二步
             document.getElementById('step1').classList.add('hidden');
             document.getElementById('step2').classList.remove('hidden');
@@ -664,7 +759,10 @@
         function continueToChat() {
             document.getElementById('step2').classList.add('hidden');
             document.getElementById('step3').classList.remove('hidden');
-            
+            document.getElementById('chatSummaryActions').classList.add('hidden');
+            summarySectionVisible = false;
+            summaryGenerated = false;
+
             // 开始AI对话
             startAIChat();
         }
@@ -697,10 +795,9 @@
                     currentQuestionIndex++;
                 }, 1000);
             } else {
-                // 所有问题都问完了，生成最终分析
                 setTimeout(() => {
-                    addChatMessage('ai', '感谢您详细的分享！现在让我为您生成完整的个性化运势报告...');
-                    setTimeout(generateFinalReport, 2000);
+                    addChatMessage('ai', '感谢您详细的分享！我们已收集到关键线索，接下来您可以先查看对话总结，再决定是否生成完整的综合运势报告。');
+                    showSummaryActions();
                 }, 1000);
             }
         }
@@ -709,29 +806,35 @@
         function addChatMessage(sender, message) {
             const chatMessages = document.getElementById('chatMessages');
             const messageDiv = document.createElement('div');
-            
+            const formattedMessage = renderMarkdown(message);
+
             if (sender === 'ai') {
-                messageDiv.className = 'ai-message rounded-lg p-4';
+                messageDiv.className = 'chat-message ai-message';
                 messageDiv.innerHTML = `
-                    <div class="flex items-start space-x-3">
-                        <div class="w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center text-white font-bold text-sm">AI</div>
-                        <div class="flex-1 text-purple-100 leading-relaxed">${message}</div>
+                    <div class="flex items-start space-x-4">
+                        <div class="w-10 h-10 bg-purple-600 rounded-full flex items-center justify-center text-white font-bold text-sm shadow-lg shadow-purple-500/30">AI</div>
+                        <div class="flex-1">
+                            <div class="message-metadata text-purple-200 mb-1 tracking-[0.25em]">MYSTIC AI</div>
+                            <div class="message-content text-purple-100 leading-relaxed">${formattedMessage}</div>
+                        </div>
                     </div>
                 `;
             } else {
-                messageDiv.className = 'user-message rounded-lg p-4';
+                messageDiv.className = 'chat-message user-message';
                 messageDiv.innerHTML = `
-                    <div class="flex items-start space-x-3 justify-end">
-                        <div class="flex-1 text-yellow-100 leading-relaxed text-right">${message}</div>
-                        <div class="w-8 h-8 bg-yellow-600 rounded-full flex items-center justify-center text-white font-bold text-sm">您</div>
+                    <div class="flex items-start space-x-4 justify-end">
+                        <div class="flex-1 text-right">
+                            <div class="message-metadata text-amber-200 mb-1 tracking-[0.3em]">用户</div>
+                            <div class="message-content text-yellow-100 leading-relaxed">${formattedMessage}</div>
+                        </div>
+                        <div class="w-10 h-10 bg-yellow-500 rounded-full flex items-center justify-center text-black font-bold text-sm shadow-lg shadow-yellow-400/30">您</div>
                     </div>
                 `;
             }
-            
+
             chatMessages.appendChild(messageDiv);
             document.getElementById('chatContainer').scrollTop = document.getElementById('chatContainer').scrollHeight;
-            
-            // 保存到对话历史
+
             conversationHistory.push({ sender, message });
         }
 
@@ -766,6 +869,7 @@
         // AI回应
         async function aiRespond(userMessage) {
             try {
+                showTypingIndicator();
                 const contextPrompt = `
                 作为AI占星师，基于用户的回答继续对话：
 
@@ -781,10 +885,117 @@
                 `;
 
                 const response = await window.mysticalAI.callDeepSeekAPI(contextPrompt, 'fortune');
+                hideTypingIndicator();
                 addChatMessage('ai', response);
-                
+
             } catch (error) {
+                hideTypingIndicator();
                 addChatMessage('ai', '我理解您的情况。让我们继续深入分析...');
+            }
+        }
+
+        function showTypingIndicator() {
+            if (typingIndicator) return;
+
+            const chatMessages = document.getElementById('chatMessages');
+            typingIndicator = document.createElement('div');
+            typingIndicator.className = 'chat-message ai-message';
+            typingIndicator.innerHTML = `
+                <div class="flex items-center space-x-3">
+                    <div class="w-10 h-10 bg-purple-600 rounded-full flex items-center justify-center text-white font-bold text-sm">AI</div>
+                    <div class="flex-1 flex space-x-2">
+                        <span class="typing-indicator"></span>
+                        <span class="typing-indicator"></span>
+                        <span class="typing-indicator"></span>
+                    </div>
+                </div>
+            `;
+
+            chatMessages.appendChild(typingIndicator);
+            document.getElementById('chatContainer').scrollTop = document.getElementById('chatContainer').scrollHeight;
+        }
+
+        function hideTypingIndicator() {
+            if (!typingIndicator) return;
+            typingIndicator.remove();
+            typingIndicator = null;
+        }
+
+        function renderMarkdown(message) {
+            if (!message) {
+                return '';
+            }
+
+            try {
+                const html = marked.parse(message);
+                return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+            } catch (error) {
+                console.warn('Markdown 渲染失败:', error);
+                return DOMPurify.sanitize(message);
+            }
+        }
+
+        function showSummaryActions() {
+            if (summarySectionVisible) return;
+
+            summarySectionVisible = true;
+            summaryGenerated = false;
+
+            const actions = document.getElementById('chatSummaryActions');
+            actions.classList.remove('hidden');
+
+            const result = document.getElementById('chatSummaryResult');
+            result.classList.add('hidden');
+            document.getElementById('chatSummaryContent').innerHTML = '';
+
+            const button = document.getElementById('generateSummaryBtn');
+            button.disabled = false;
+            button.textContent = '🪄 生成对话总结';
+        }
+
+        async function requestChatSummary() {
+            if (summaryGenerated) return;
+
+            const button = document.getElementById('generateSummaryBtn');
+            button.disabled = true;
+            button.textContent = '✨ 正在生成...';
+
+            const summaryResult = document.getElementById('chatSummaryResult');
+            summaryResult.classList.remove('hidden');
+            document.getElementById('chatSummaryContent').innerHTML = '<div class="text-gray-300">AI正在整理关键信息...</div>';
+
+            try {
+                const summaryPrompt = `
+                作为AI占星师，请用温暖且专业的口吻，总结以下对话中的关键信息，并对用户最初的问题给出两点简洁的回应：
+
+                用户基础信息：
+                - 生日：${userProfile.birthDate}
+                - 星座：${userProfile.zodiacSign?.name || '未知'}
+                - 初始问题：${userProfile.mainConcern}
+                - 关注领域：${userProfile.focusAreas.join('、') || '未指定'}
+
+                对话交流：
+                ${conversationHistory.map(entry => `${entry.sender === 'ai' ? 'AI' : '用户'}: ${entry.message}`).join('\n')}
+
+                请输出Markdown格式：
+                - 以二级标题开头，例如“## 今日对话摘要”。
+                - 列出运势核心要点的无序列表。
+                - 使用有序列表简要回答用户的原始问题，每点不超过30字。
+                - 最后给出一句鼓励性的提醒。
+                字数控制在120-180字。
+                `;
+
+                const summary = await window.mysticalAI.callDeepSeekAPI(summaryPrompt, 'fortune');
+                const content = renderMarkdown(summary);
+                document.getElementById('chatSummaryContent').innerHTML = content;
+                summaryGenerated = true;
+            } catch (error) {
+                console.error('总结生成失败:', error);
+                document.getElementById('chatSummaryContent').innerHTML = '<div class="text-red-300">抱歉，总结生成失败，请稍后重试。</div>';
+                summaryGenerated = false;
+            } finally {
+                button.disabled = summaryGenerated;
+                button.textContent = summaryGenerated ? '✅ 已生成总结' : '🪄 生成对话总结';
             }
         }
 
@@ -900,13 +1111,21 @@
             conversationHistory = [];
             currentQuestionIndex = 0;
             analysisData = {};
-            
+            followUpQuestions = [];
+            typingIndicator = null;
+            summarySectionVisible = false;
+            summaryGenerated = false;
+
             // 重置界面
             document.getElementById('step1').classList.remove('hidden');
             document.getElementById('step2').classList.add('hidden');
             document.getElementById('step3').classList.add('hidden');
             document.getElementById('step4').classList.add('hidden');
-            
+            document.getElementById('chatMessages').innerHTML = '';
+            document.getElementById('chatSummaryActions').classList.add('hidden');
+            document.getElementById('chatSummaryResult').classList.add('hidden');
+            document.getElementById('chatSummaryContent').innerHTML = '';
+
             // 清空输入
             document.getElementById('birthDate').value = '';
             document.getElementById('birthTime').value = '';

--- a/fortune.html
+++ b/fortune.html
@@ -220,7 +220,6 @@
                         <a href="index.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">首页</a>
                         <a href="fortune.html" class="nav-link text-yellow-400 hover:text-white px-3 py-2 text-sm font-medium">运势计算</a>
                         <a href="tarot.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">塔罗占卜</a>
-                        <a href="astrology.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">星象分析</a>
                         <a href="settings.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">🔑 设置</a>
                         <a href="test-api.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">🧪 测试</a>
                     </div>
@@ -483,7 +482,6 @@
                 <a href="index.html" class="text-gray-400 hover:text-yellow-400 transition-colors">首页</a>
                 <a href="fortune.html" class="text-yellow-400 hover:text-white transition-colors">运势计算</a>
                 <a href="tarot.html" class="text-gray-400 hover:text-yellow-400 transition-colors">塔罗占卜</a>
-                <a href="astrology.html" class="text-gray-400 hover:text-yellow-400 transition-colors">星象分析</a>
             </div>
             <p class="text-gray-500 text-sm">© 2025 神秘AI. 仅供娱乐参考，请理性对待占卜结果</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -180,9 +180,8 @@
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-8">
                         <a href="index.html" class="nav-link text-yellow-400 hover:text-white px-3 py-2 text-sm font-medium">首页</a>
-                        <a href="fortune.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">运势计算</a>
+                        <a href="fortune-new.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">运势计算</a>
                         <a href="tarot.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">塔罗占卜</a>
-                        <a href="astrology.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">星象分析</a>
                         <a href="settings.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">🔑 设置</a>
                         <a href="test-api.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">🧪 测试</a>
                     </div>
@@ -205,7 +204,7 @@
                 通过AI技术深度解析塔罗牌、星座运势和神秘符号，为您提供专业而神秘的占卜体验
             </div>
             <div class="flex flex-col sm:flex-row gap-6 justify-center fade-in" id="hero-buttons">
-                <button onclick="window.location.href='fortune.html'" class="glow-button px-8 py-4 rounded-full text-black font-bold text-lg">
+                <button onclick="window.location.href='fortune-new.html'" class="glow-button px-8 py-4 rounded-full text-black font-bold text-lg">
                     🎯 开始算命
                 </button>
                 <button onclick="scrollToFeatures()" class="border-2 border-yellow-400 text-yellow-400 hover:bg-yellow-400 hover:text-black px-8 py-4 rounded-full font-bold text-lg transition-all duration-300">
@@ -257,7 +256,7 @@
                             <div class="bg-gradient-to-r from-yellow-400 to-yellow-600 h-2 rounded-full" style="width: 85%"></div>
                         </div>
                     </div>
-                    <button onclick="window.location.href='fortune.html'" class="glow-button px-6 py-3 rounded-full text-black font-bold">
+                    <button onclick="window.location.href='fortune-new.html'" class="glow-button px-6 py-3 rounded-full text-black font-bold">
                         立即测算
                     </button>
                 </div>
@@ -288,23 +287,25 @@
                     </button>
                 </div>
 
-                <!-- 星象分析 -->
+                <!-- 对话总结 -->
                 <div class="mystical-card rounded-2xl p-8 text-center floating" style="animation-delay: 2s;">
-                    <div class="feature-icon">⭐</div>
-                    <h3 class="text-2xl font-bold text-yellow-400 mb-4">星象分析</h3>
+                    <div class="feature-icon">📝</div>
+                    <h3 class="text-2xl font-bold text-yellow-400 mb-4">对话式运势总结</h3>
                     <p class="text-gray-300 mb-6">
-                        基于您的星座和当前天体位置，深度分析星象对您生活各方面的影响和指引
+                        与AI完成深度对话后，即时生成结构化总结，帮助您快速提炼要点、锁定关键行动。
                     </p>
-                    <div class="flex justify-center mb-6">
-                        <div class="w-32 h-32 relative">
-                            <img src="resources/zodiac-circle.jpg" alt="星座图" class="w-full h-full rounded-full border-2 border-yellow-400 animate-spin" style="animation-duration: 20s;">
-                            <div class="absolute inset-0 flex items-center justify-center">
-                                <span class="text-3xl">♈</span>
-                            </div>
+                    <div class="grid grid-cols-2 gap-4 text-left mb-6">
+                        <div class="bg-black bg-opacity-50 rounded-xl p-4 border border-yellow-900">
+                            <div class="text-yellow-400 font-bold mb-2">🧭 重点回顾</div>
+                            <p class="text-gray-400 text-sm leading-relaxed">自动整理AI与您的核心对话，高亮能量趋势与情绪线索。</p>
+                        </div>
+                        <div class="bg-black bg-opacity-50 rounded-xl p-4 border border-yellow-900">
+                            <div class="text-yellow-400 font-bold mb-2">🪄 快速指引</div>
+                            <p class="text-gray-400 text-sm leading-relaxed">以简洁步骤回应最初的问题，为下一步行动提供方向。</p>
                         </div>
                     </div>
-                    <button onclick="window.location.href='astrology.html'" class="glow-button px-6 py-3 rounded-full text-black font-bold">
-                        查看星象
+                    <button onclick="window.location.href='fortune-new.html#step3'" class="glow-button px-6 py-3 rounded-full text-black font-bold">
+                        体验AI总结
                     </button>
                 </div>
             </div>
@@ -361,9 +362,8 @@
             <p class="text-gray-400 mb-8">探索未知，洞察未来，体验神秘的占卜之旅</p>
             <div class="flex justify-center space-x-8 mb-8">
                 <a href="index.html" class="text-yellow-400 hover:text-white transition-colors">首页</a>
-                <a href="fortune.html" class="text-gray-400 hover:text-yellow-400 transition-colors">运势计算</a>
+                <a href="fortune-new.html" class="text-gray-400 hover:text-yellow-400 transition-colors">运势计算</a>
                 <a href="tarot.html" class="text-gray-400 hover:text-yellow-400 transition-colors">塔罗占卜</a>
-                <a href="astrology.html" class="text-gray-400 hover:text-yellow-400 transition-colors">星象分析</a>
             </div>
             <p class="text-gray-500 text-sm">© 2025 神秘AI. 仅供娱乐参考，请理性对待占卜结果</p>
         </div>

--- a/tarot.html
+++ b/tarot.html
@@ -285,9 +285,8 @@
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-8">
                         <a href="index.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">首页</a>
-                        <a href="fortune.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">运势计算</a>
+                        <a href="fortune-new.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">运势计算</a>
                         <a href="tarot.html" class="nav-link text-yellow-400 hover:text-white px-3 py-2 text-sm font-medium">塔罗占卜</a>
-                        <a href="astrology.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">星象分析</a>
                         <a href="settings.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">🔑 设置</a>
                         <a href="test-api.html" class="nav-link text-white hover:text-yellow-400 px-3 py-2 text-sm font-medium">🧪 测试</a>
                     </div>
@@ -444,7 +443,14 @@
                             <!-- 总结内容将通过JavaScript生成 -->
                         </div>
                     </div>
-                    
+
+                    <div id="finalAdviceContainer" class="mystical-card rounded-2xl p-8 mt-6 hidden">
+                        <h3 class="text-2xl font-bold text-yellow-400 mb-4">💡 最终指引</h3>
+                        <div id="finalAdviceContent" class="text-gray-200 leading-relaxed space-y-4">
+                            <!-- 最终建议将通过JavaScript生成 -->
+                        </div>
+                    </div>
+
                     <!-- 操作按钮 -->
                     <div class="text-center mt-12 space-x-4">
                         <button onclick="shareReading()" class="glow-button px-6 py-3 rounded-full text-black font-bold">
@@ -466,9 +472,8 @@
             <p class="text-gray-400 mb-8">探索未知，洞察未来，体验神秘的占卜之旅</p>
             <div class="flex justify-center space-x-8 mb-8">
                 <a href="index.html" class="text-gray-400 hover:text-yellow-400 transition-colors">首页</a>
-                <a href="fortune.html" class="text-gray-400 hover:text-yellow-400 transition-colors">运势计算</a>
+                <a href="fortune-new.html" class="text-gray-400 hover:text-yellow-400 transition-colors">运势计算</a>
                 <a href="tarot.html" class="text-yellow-400 hover:text-white transition-colors">塔罗占卜</a>
-                <a href="astrology.html" class="text-gray-400 hover:text-yellow-400 transition-colors">星象分析</a>
             </div>
             <p class="text-gray-500 text-sm">© 2025 神秘AI. 仅供娱乐参考，请理性对待占卜结果</p>
         </div>
@@ -481,6 +486,36 @@
         let selectedSpread = '';
         let drawnCards = [];
         let cardsRevealed = 0;
+
+        const topicDescriptions = {
+            love: '爱情运势',
+            career: '事业发展',
+            wealth: '财运分析',
+            health: '健康状况'
+        };
+
+        const topicAdviceMap = {
+            love: [
+                '保持开放的心态，真诚沟通，勇于表达真实感受。',
+                '为关系预留高质量的相处时间，营造温暖氛围。',
+                '倾听自己的直觉，尊重彼此的节奏。'
+            ],
+            career: [
+                '明确短期目标，按照计划推进核心任务。',
+                '积极寻求合作或导师支持，拓展资源。',
+                '在关键节点勇敢表达观点，展示专业实力。'
+            ],
+            wealth: [
+                '审视现金流和支出结构，为资金制定缓冲带。',
+                '优先选择熟悉领域的稳健理财方式。',
+                '设定阶段储蓄目标，避免冲动消费。'
+            ],
+            health: [
+                '建立稳定的作息节奏，保证充足睡眠。',
+                '安排规律运动或身心疗愈活动舒缓压力。',
+                '关注饮食与情绪之间的关系，适时求助专业人士。'
+            ]
+        };
         
         // 页面加载完成后初始化
         document.addEventListener('DOMContentLoaded', function() {
@@ -788,12 +823,13 @@
             
             // 生成AI解读
             await generateAIInterpretation();
-            
+
             generateReadingSummary();
-            
+            updateFinalAdvice();
+
             // 滚动到解读区域
-            document.getElementById('interpretationSection').scrollIntoView({ 
-                behavior: 'smooth' 
+            document.getElementById('interpretationSection').scrollIntoView({
+                behavior: 'smooth'
             });
         }
         
@@ -923,15 +959,8 @@
         // 生成占卜总结
         function generateReadingSummary() {
             const summaryDiv = document.getElementById('readingSummary');
-            const topicDescriptions = {
-                love: '爱情运势',
-                career: '事业发展',
-                wealth: '财运分析',
-                health: '健康状况'
-            };
-
             const question = document.getElementById('questionInput').value.trim();
-            const topic = topicDescriptions[selectedTopic];
+            const topic = topicDescriptions[selectedTopic] || '整体运势';
 
             let summary = `根据您对"${topic}"的询问："${question}"，塔罗牌给出了以下指引：`;
 
@@ -948,35 +977,12 @@
             }
 
             // 根据主题添加特定建议
-            const topicAdvice = {
-                love: [
-                    '保持开放的心态，真诚沟通，勇于表达真实感受。',
-                    '为关系预留高质量的相处时间，营造温暖氛围。',
-                    '倾听自己的直觉，尊重彼此的节奏。'
-                ],
-                career: [
-                    '明确短期目标，按照计划推进核心任务。',
-                    '积极寻求合作或导师支持，拓展资源。',
-                    '在关键节点勇敢表达观点，展示专业实力。'
-                ],
-                wealth: [
-                    '审视现金流和支出结构，为资金制定缓冲带。',
-                    '优先选择熟悉领域的稳健理财方式。',
-                    '设定阶段性储蓄目标，避免冲动消费。'
-                ],
-                health: [
-                    '建立稳定的作息节奏，保证充足睡眠。',
-                    '安排规律运动或身心疗愈活动舒缓压力。',
-                    '关注饮食与情绪之间的关系，适时求助专业人士。'
-                ]
-            };
-
             const cardHighlights = drawnCards.map((card, index) => {
                 const meaning = card.isReversed ? card.reverse : card.meaning;
                 return `• ${getCardPosition(index)}的${card.name}${card.isReversed ? '(逆位)' : ''}：${meaning}`;
             }).join('\n');
 
-            const actionSteps = (topicAdvice[selectedTopic] || []).map(step => `- ${step}`).join('\n');
+            const actionSteps = (topicAdviceMap[selectedTopic] || []).map(step => `- ${step}`).join('\n');
 
             summary += `\n\n🔑 关键牌面启示：\n${cardHighlights}`;
 
@@ -988,7 +994,68 @@
 
             summaryDiv.textContent = summary;
         }
-        
+
+        function updateFinalAdvice() {
+            const container = document.getElementById('finalAdviceContainer');
+            const content = document.getElementById('finalAdviceContent');
+
+            if (!drawnCards.length) {
+                container.classList.add('hidden');
+                content.innerHTML = '';
+                return;
+            }
+
+            const question = document.getElementById('questionInput').value.trim();
+            const topicLabel = topicDescriptions[selectedTopic] || '当前主题';
+            const uprightCards = drawnCards.filter(card => !card.isReversed).length;
+            const reversedCards = drawnCards.length - uprightCards;
+
+            let toneMessage = '整体能量保持在平衡状态，关键在于审视自己的节奏与选择。';
+            if (uprightCards > reversedCards) {
+                toneMessage = '整体能量呈现积极走势，适合把握契机、主动推进计划。';
+            } else if (reversedCards > uprightCards) {
+                toneMessage = '牌阵能量略显紧张，请稳住节奏、谨慎评估每一步的影响。';
+            }
+
+            const keyCard = drawnCards[0];
+            const finalCard = drawnCards[drawnCards.length - 1];
+            const keyMeaning = keyCard ? (keyCard.isReversed ? keyCard.reverse : keyCard.meaning) : '';
+            const finalMeaning = finalCard ? (finalCard.isReversed ? finalCard.reverse : finalCard.meaning) : '';
+
+            const cautions = [];
+            if (reversedCards > 0) {
+                cautions.push(`牌阵中出现${reversedCards}张逆位牌，提醒你留意潜在的阻力与情绪波动。`);
+            }
+            if (finalCard) {
+                cautions.push(`${getCardPosition(drawnCards.length - 1)}位置的${finalCard.name}${finalCard.isReversed ? '(逆位)' : ''}提示：${finalMeaning}`);
+            }
+
+            const actions = (topicAdviceMap[selectedTopic] || []).slice(0, 2);
+            const questionLine = question ? `结合你关于“${question}”的提问，` : '';
+            const coreInsight = keyCard
+                ? `「${keyCard.name}${keyCard.isReversed ? '·逆位' : ''}」落在${getCardPosition(0)}位置，象征${keyMeaning}。`
+                : '';
+
+            content.innerHTML = `
+                <div class="space-y-4">
+                    <div class="p-4 rounded-xl bg-black bg-opacity-40 border border-yellow-500/40">
+                        <h4 class="text-yellow-300 font-bold mb-2">核心洞察</h4>
+                        <p class="text-sm md:text-base text-gray-200 leading-relaxed">${toneMessage}${coreInsight ? ` ${coreInsight}` : ''} ${questionLine}请在${topicLabel}中保持觉察与主动。</p>
+                    </div>
+                    ${cautions.length ? `<div><h4 class="text-yellow-300 font-bold mb-2">需要留意</h4><ul class="list-disc pl-5 space-y-2 text-sm md:text-base text-gray-300">${cautions.map(item => `<li>${item}</li>`).join('')}</ul></div>` : ''}
+                    <div>
+                        <h4 class="text-yellow-300 font-bold mb-2">行动建议</h4>
+                        <ol class="list-decimal pl-5 space-y-2 text-sm md:text-base text-gray-200">
+                            ${(actions.length ? actions : ['保持对内在声音的倾听，循序渐进地调整计划。']).map(item => `<li>${item}</li>`).join('')}
+                        </ol>
+                    </div>
+                    <p class="text-sm text-gray-400">请在接下来的七天内记录灵感或重要事件，以便与未来的占卜呼应。</p>
+                </div>
+            `;
+
+            container.classList.remove('hidden');
+        }
+
         // 更新占卜指引
         function updateReadingInstruction() {
             const instructions = {
@@ -1052,7 +1119,9 @@
             // 清除解读内容
             document.getElementById('cardInterpretations').innerHTML = '';
             document.getElementById('interpretationSection').classList.add('hidden');
-            
+            document.getElementById('finalAdviceContainer').classList.add('hidden');
+            document.getElementById('finalAdviceContent').innerHTML = '';
+
             // 滚动到顶部
             window.scrollTo({ top: 0, behavior: 'smooth' });
         }


### PR DESCRIPTION
## Summary
- restyle the AI运势对话界面 with markdown-rendered chat bubbles, typing indicator, and a new post-conversation summary option
- remove the retired 星象分析 page from navigation/CTA areas and highlight the new conversation summary feature on the homepage
- extend塔罗占卜结果 with a final guidance card that distills key insights and action items

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7ad45cae08322b69ba3e11ac24016