### PR TITLE
Prevent duplicate summary prompts in follow-up flow

### DIFF
--- a/fortune-new.html
+++ b/fortune-new.html
@@ -395,6 +395,7 @@
         let typingIndicator = null;
         let summarySectionVisible = false;
         let summaryGenerated = false;
+        let followUpCompleted = false;
 
         marked.setOptions({
             breaks: true,
@@ -762,6 +763,7 @@
             document.getElementById('chatSummaryActions').classList.add('hidden');
             summarySectionVisible = false;
             summaryGenerated = false;
+            followUpCompleted = false;
 
             // 开始AI对话
             startAIChat();
@@ -787,6 +789,10 @@
                 followUpQuestions = [...defaultFollowUps];
             }
 
+            if (followUpCompleted) {
+                return;
+            }
+
             if (currentQuestionIndex < followUpQuestions.length) {
                 const question = followUpQuestions[currentQuestionIndex];
 
@@ -794,7 +800,9 @@
                     addChatMessage('ai', question);
                     currentQuestionIndex++;
                 }, 1000);
-            } else {
+            } else if (!followUpCompleted) {
+                followUpCompleted = true;
+                currentQuestionIndex = followUpQuestions.length + 1;
                 setTimeout(() => {
                     addChatMessage('ai', '感谢您详细的分享！我们已收集到关键线索，接下来您可以先查看对话总结，再决定是否生成完整的综合运势报告。');
                     showSummaryActions();
@@ -862,7 +870,9 @@
                 document.getElementById('userInputArea').style.opacity = '1';
                 
                 // 继续提问
-                setTimeout(askNextQuestion, 1500);
+                if (!followUpCompleted) {
+                    setTimeout(askNextQuestion, 1500);
+                }
             }, 1000);
         }
 
@@ -1115,6 +1125,7 @@
             typingIndicator = null;
             summarySectionVisible = false;
             summaryGenerated = false;
+            followUpCompleted = false;
 
             // 重置界面
             document.getElementById('step1').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- add a follow-up completion flag to track when scripted questions have ended
- ensure askNextQuestion only posts the summary invitation once and locks the index
- guard sendMessage so no additional prompts fire after the follow-up phase completes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7bf88a9d083229c4693331b7fa57c