### PR TITLE
Fix focus area mapping before joining descriptions

### DIFF
--- a/fortune-new.html
+++ b/fortune-new.html
@@ -706,13 +706,15 @@
 
         async function prepareFollowUpPlan(initialAnalysisText) {
             try {
-                const focusDescription = userProfile.focusAreas.length
-                    ? userProfile.focusAreas.map(area => ({
-                        love: '感情',
-                        career: '事业',
-                        wealth: '财务',
-                        health: '健康'
-                    }[area] || area).join('、'))
+                const focusDescriptions = userProfile.focusAreas.map(area => ({
+                    love: '感情',
+                    career: '事业',
+                    wealth: '财务',
+                    health: '健康'
+                }[area] || area);
+
+                const focusDescription = focusDescriptions.length
+                    ? focusDescriptions.join('、')
                     : '整体生活状态';
 
                 const planPrompt = `


### PR DESCRIPTION
## Summary
- ensure focus area labels are mapped before joining to avoid runtime errors in follow-up planning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7bf89aba08322898b59e01770b1c0